### PR TITLE
add processing time at the end of the book conversions.

### DIFF
--- a/epubify/epubify.py
+++ b/epubify/epubify.py
@@ -50,6 +50,9 @@ class Epubify(object):
             # update filePath to the dict which will be passed onto the save_book method
             print(">> The book will be saved at: [%s] " % self.file_path)
 
+    def get_book_title(self):
+        return self.title, self.author
+
     def fetch_html_text(self):
         try:
             response = requests.get(self.url, verify=False)

--- a/epubify/main.py
+++ b/epubify/main.py
@@ -1,7 +1,7 @@
 import json, argparse
 from sys import argv, exit
 from .epubify import Epubify
-from .utils.utils import read_json, read_txt, start_time, end_time
+from .utils.utils import read_json, read_txt, start_time, end_time, write_to_file
 from epubify.utils.ascii_art import books, llama_small, error404
 
 
@@ -159,6 +159,7 @@ def process_book(preprocess=True, **config):
             % err
         )
         print(error404)
+        write_to_file('epubify/books/FAILED.txt', "\t - " + epub.get_book_title()[0])
     print("=" * 100)
 
 
@@ -200,6 +201,7 @@ def run(**config):
             "or have entered unsupported source system, other than 'url', 'txt', or 'pocket'"
         )
     print(books)
+    print("The articles that failed to be processed (if any) are stored in 'epubify/books/FAILED.txt'.")
     end_time()
    
 

--- a/epubify/utils/utils.py
+++ b/epubify/utils/utils.py
@@ -19,6 +19,11 @@ def system_import(sys, **config):
     return system_instance
 
 
+def write_to_file(file_path, file_content):
+    with open(file_path, 'a') as oFile:
+        oFile.write(file_content + '\n')
+
+
 def start_time():
     global _start_time
     _start_time = time.time()


### PR DESCRIPTION
- [x] add new file `epubify/books/FAILED.txt` with articles that could not be processed. 